### PR TITLE
HTTPS packagist reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "http://wpackagist.org"
+      "url": "https://wpackagist.org"
     },
     {
       "type": "package",


### PR DESCRIPTION
The latest release of composer trips up on insecure references by default
